### PR TITLE
Initialization support and vagrant env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+#Virtualenv env
+venv
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+#lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Vagrant
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 
 # Vagrant
 .vagrant
+
+# CoinHSL - proprietary files so no add in the repo
+coinhsl*

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ cyipopt is a python wrapper around Ipopt. It enables using Ipopt from the
 comfort of the great Python scripting language.
 
 Ipopt is available from the `COIN-OR <https://projects.coin-or.org/Ipopt>`_
-initiative, under the Eclipse Public License (EPL). 
+initiative, under the Eclipse Public License (EPL).
 
 
 Usage
@@ -70,6 +70,19 @@ start the container by::
 
 and either call `ipopt` directly or start a ipython shell and `import ipopt`.
 
+Vagrant environment
+===================
+
+The subdirectory `vagrant` contains a `Vagrantfile` that installs ipopt and cyipopt in OS provision.
+To build the environment, cd into the `vagrant` directory and run `vagrant up` (Requires that you have Vagrant+VirtualBox installed). Then you can
+access the system by::
+
+   vagrant ssh
+
+and either call `ipopt` directly or start a python shell and `import ipopt`.
+Also, if you get `source files <http://www.coin-or.org/download/binary/Ipopt/>` of coinhsl and put it
+in the `vagrant` directory, the vagrant provision will detect and add them in the ipopt compiling process, and
+then you will have ma57, ma27, and other solvers available on ipopt binary (ma97 and mc68 were removed to avoid compilation errors).
 
 Reading the docs
 ================

--- a/src/cyipopt.pyx
+++ b/src/cyipopt.pyx
@@ -495,7 +495,7 @@ cdef class problem:
 
     def solve(
             self,
-            x
+            x,lagrange=[],zl=[],zu=[]
             ):
         """
         Solve the posed optimization problem starting at point x.
@@ -539,9 +539,22 @@ cdef class problem:
 
         cdef ApplicationReturnStatus stat
         cdef np.ndarray[DTYPEd_t, ndim=1] g = np.zeros((self.__m,), dtype=DTYPEd)
-        cdef np.ndarray[DTYPEd_t, ndim=1] mult_g = np.zeros((self.__m,), dtype=DTYPEd)
-        cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_L = np.zeros((self.__n,), dtype=DTYPEd)
-        cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_U = np.zeros((self.__n,), dtype=DTYPEd)
+
+        #cdef np.ndarray[DTYPEd_t, ndim=1] mult_g = np.zeros((self.__m,), dtype=DTYPEd)
+        #cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_L = np.zeros((self.__n,), dtype=DTYPEd)
+        #cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_U = np.zeros((self.__n,), dtype=DTYPEd)
+
+        if lagrange == []:
+            lagrange = np.zeros((self.__m,), dtype=DTYPEd)
+        cdef np.ndarray[DTYPEd_t, ndim=1] mult_g = np.array(lagrange, dtype=DTYPEd).flatten()
+
+        if zl == []:
+            zl = np.zeros((self.__n,), dtype=DTYPEd)
+        if zu == []:
+            zu = np.zeros((self.__n,), dtype=DTYPEd)
+        cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_L = np.array(zl, dtype=DTYPEd).flatten()
+        cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_U = np.array(zu, dtype=DTYPEd).flatten()
+
 
         cdef Number obj_val = 0
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -11,6 +11,29 @@ cd /home/vagrant
 wget -c http://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.4.zip
 unzip Ipopt-3.12.4.zip && cd Ipopt-3.12.4/
 export IPOPTDIR=/home/vagrant/Ipopt-3.12.4/
+
+echo "Checking for coinhsl file in /vagrant directory..."
+cd /vagrant
+FILE=$(ls coinhsl*)
+echo "File: $FILE"
+if [ -f "$FILE" ]; then
+    if [[ $FILE == *coinhsl* ]]; then
+      echo "coinhsl file found... adding to compilation"
+      if [[ $FILE == *gz* ]]; then
+        tar xzf $FILE
+      elif [[ $FILE == *zip* ]]; then
+        unzip $FILE
+      fi
+      DIRHSL=$(find /vagrant -type d -name 'coinhsl*')
+      mv $DIRHSL $IPOPTDIR/ThirdParty/HSL/coinhsl
+      rm -fr $IPOPTDIR/ThirdParty/HSL/coinhsl/hsl_mc68
+      rm -fr $IPOPTDIR/ThirdParty/HSL/coinhsl/hsl_ma97
+      #sudo cp -vr $DIRHSL/lib/* /usr/local/lib
+      #sudo cp -vr $DIRHSL/include/* /usr/local/include
+      sudo rm -fr $DIRHSL
+    fi
+fi
+
 cd $IPOPTDIR/ThirdParty/Blas
 ./get.Blas
 cd ../Lapack && ./get.Lapack

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,69 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+echo "Starting provision to have an ipopt node system with python interface..."
+sudo apt-get update
+sudo apt-get -y dist-upgrade
+sudo apt-get -y install g++ gfortran unzip git wget liblapack-dev cython pkg-config
+
+cd /home/vagrant
+wget -c http://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.4.zip
+unzip Ipopt-3.12.4.zip && cd Ipopt-3.12.4/
+export IPOPTDIR=/home/vagrant/Ipopt-3.12.4/
+cd $IPOPTDIR/ThirdParty/Blas
+./get.Blas
+cd ../Lapack && ./get.Lapack
+cd ../ASL && ./get.ASL
+cd ../Mumps && ./get.Mumps
+mkdir $IPOPTDIR/build
+cd $IPOPTDIR/build
+sudo chown -R vagrant:vagrant /home/vagrant
+$IPOPTDIR/configure --prefix=/opt/ipopt/
+make
+make test
+sudo make install
+sudo echo "/opt/ipopt/lib" > /etc/ld.so.conf.d/ipopt.conf
+sudo ldconfig
+sudo echo 'export IPOPTPATH="/opt/ipopt"' >> /etc/profile
+sudo echo "export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/ipopt/lib/pkgconfig" >> /etc/profile
+sudo echo 'export PATH=$PATH:$IPOPTPATH/bin' >> /etc/profile
+sudo echo 'export LAPACK=/usr/lib/liblapack.so' >> /etc/profile
+sudo echo 'export ATLAS=/usr/lib/libatlas.so' >> /etc/profile
+sudo echo 'export BLAS=/usr/lib/libblas.so' >> /etc/profile
+source /etc/profile
+
+sudo apt-get -y install python-dev python-virtualenv python-pip python-numpy python-scipy
+#sudo pip install numpy
+#sudo pip install scipy
+
+cd /home/vagrant
+git clone https://github.com/matthias-k/cyipopt
+cd cyipopt
+sudo chown -R vagrant:vagrant /home/vagrant
+PKG_CONFIG_PATH=/opt/ipopt/lib/pkgconfig python setup.py install
+cd test
+python -c "import ipopt"
+python examplehs071.py
+cd ..
+
+SCRIPT
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.synced_folder "../", "/home/vagrant/files", create: true
+  # Use an Ubuntu box based in the host arch
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "ipopt-node"
+  config.vm.provider :virtualbox do |vb, override|
+    vb.name = "ipopt-node"
+    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/files", "1"]
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    override.vm.provision "shell", inline: $script
+  end
+  # Provision without puppet or cheff, using shell scripts
+  # config.vm.provision :shell, path: "./provision/ubuntu_provision.sh"
+  # X11 over ssh
+  config.ssh.forward_x11 = true
+end


### PR DESCRIPTION
The commit list presented are related with this two main changes:
1 - Added initialization support for mult_g, mult_x_L and mult_x_U. The Matlab interface support that you can provide values to initialize these structures, so to keep compatibility with a port that I made from Matlab to python, I need to add this because it changes how the problem is solved in ipopt, also the number of iterations in the optimization process.
Example of my initialization::

    # set up initial primal solution
    x0 = npmean( nparray([ lowerbounds,  upperbounds]),axis=0 )
    # set up initial dual solution
    zl = npmax(npabs(x0),10)
    zu = npcopy(zl)
    lagrange = npones(obj.m)
    # solve problem
    xot, info = nlp.solve(x=x0,lagrange=lagrange,zl=zl,zu=zu)

The defintion for the solve method is now::

    def solve(self,x,lagrange=[],zl=[],zu=[]):

And the changes in the structure creation are::

        #cdef np.ndarray[DTYPEd_t, ndim=1] mult_g = np.zeros((self.__m,), dtype=DTYPEd)
        #cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_L = np.zeros((self.__n,), dtype=DTYPEd)
        #cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_U = np.zeros((self.__n,), dtype=DTYPEd)

        if lagrange == []:
            lagrange = np.zeros((self.__m,), dtype=DTYPEd)
        cdef np.ndarray[DTYPEd_t, ndim=1] mult_g = np.array(lagrange, dtype=DTYPEd).flatten()

        if zl == []:
            zl = np.zeros((self.__n,), dtype=DTYPEd)
        if zu == []:
            zu = np.zeros((self.__n,), dtype=DTYPEd)
        cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_L = np.array(zl, dtype=DTYPEd).flatten()
        cdef np.ndarray[DTYPEd_t, ndim=1] mult_x_U = np.array(zu, dtype=DTYPEd).flatten()

So, no impact in the old implementations using your cyipopt driver.

2 - Added a vagrant environment. Since I use osx, for me is a waste use docker because it will run a linux box to do its magic, so when the system is not linux I prefer to use vagrant. Also, in the compiling process, the shell script used for provision will look for coinhsl sources in the vagrant file, and if it founds the HSL thirdparty features (coinhsl solvers) will be added in the compilation of the ipopt.

Thank you for the repo. Good job!
Best Regards
André