### PR TITLE
Python 2 and 3 now accept strings and bytes for addOption, fixes #27.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ script:
   - python test/examplehs071.py
   - python test/exception_handling.py
   - python test/lasso.py
+  - python test/rosen.py
   # Make sure the docs build.
   - cd doc && make html && cd ..

--- a/src/cyipopt.pyx
+++ b/src/cyipopt.pyx
@@ -395,7 +395,7 @@ cdef class problem:
 
         self.__nlp = NULL
 
-    def addOption(self, char* keyword, val):
+    def addOption(self, keyword, val):
         """
         Add a keyword/value option pair to the problem. See the IPOPT
         documentaion for details on available options.
@@ -413,6 +413,11 @@ cdef class problem:
         -------
             None
         """
+        if six.PY3 and isinstance(keyword, type('')):
+            keyword = bytes(keyword, 'utf-8')
+
+        if six.PY3 and isinstance(val, type('')):
+            val = bytes(val, 'utf-8')
 
         if isinstance(val, six.binary_type):
             ret_val = AddIpoptStrOption(self.__nlp, keyword, val)

--- a/src/cyipopt.pyx
+++ b/src/cyipopt.pyx
@@ -419,6 +419,12 @@ cdef class problem:
         if six.PY3 and isinstance(val, type('')):
             val = bytes(val, 'utf-8')
 
+        # NOTE : The strings passed in PY2 seem to be of type unicode.
+        if six.PY2:
+            keyword = str(keyword)
+            if isinstance(val, type(u'')):
+                val = str(val)
+
         if isinstance(val, six.binary_type):
             ret_val = AddIpoptStrOption(self.__nlp, keyword, val)
         elif type(val) == float:

--- a/test/examplehs071.py
+++ b/test/examplehs071.py
@@ -139,9 +139,9 @@ def main():
     #
     # Set solver options
     #
-    #nlp.addOption(b'derivative_test', b'second-order')
-    nlp.addOption(b'mu_strategy', b'adaptive')
-    nlp.addOption(b'tol', 1e-7)
+    #nlp.addOption('derivative_test', 'second-order')
+    nlp.addOption('mu_strategy', 'adaptive')
+    nlp.addOption('tol', 1e-7)
 
     #
     # Scale the problem (Just for demonstration purposes)
@@ -150,7 +150,7 @@ def main():
         obj_scaling=2,
         x_scaling=[1, 1, 1, 1]
         )
-    nlp.addOption(b'nlp_scaling_method', b'user-scaling')
+    nlp.addOption('nlp_scaling_method', 'user-scaling')
 
     #
     # Solve the problem

--- a/test/exception_handling.py
+++ b/test/exception_handling.py
@@ -145,8 +145,8 @@ def main():
     # Set solver options
     #
     #nlp.addOption('derivative_test', 'second-order')
-    nlp.addOption(b'mu_strategy', b'adaptive')
-    nlp.addOption(b'tol', 1e-7)
+    nlp.addOption('mu_strategy', 'adaptive')
+    nlp.addOption('tol', 1e-7)
 
     #
     # Scale the problem (Just for demonstration purposes)
@@ -155,7 +155,7 @@ def main():
         obj_scaling=2,
         x_scaling=[1, 1, 1, 1]
         )
-    nlp.addOption(b'nlp_scaling_method', b'user-scaling')
+    nlp.addOption('nlp_scaling_method', 'user-scaling')
 
     #
     # Solve the problem

--- a/test/lasso.py
+++ b/test/lasso.py
@@ -51,12 +51,12 @@ class lasso(ipopt.problem):
         #
         # Set solver options
         #
-        self.addOption(b'derivative_test', b'second-order')
-        self.addOption(b'jac_d_constant', b'yes')
-        self.addOption(b'hessian_constant', b'yes')
-        self.addOption(b'mu_strategy', b'adaptive')
-        self.addOption(b'max_iter', 100)
-        self.addOption(b'tol', 1e-8)
+        self.addOption('derivative_test', 'second-order')
+        self.addOption('jac_d_constant', 'yes')
+        self.addOption('hessian_constant', 'yes')
+        self.addOption('mu_strategy', 'adaptive')
+        self.addOption('max_iter', 100)
+        self.addOption('tol', 1e-8)
 
     def solve(self, _lambda):
 
@@ -129,7 +129,8 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p','--plot', help='Plot results with matplotlib', action='store_true')
+    parser.add_argument('-p','--plot', help='Plot results with matplotlib',
+                        action='store_true')
     args = parser.parse_args()
 
 

--- a/test/rosen.py
+++ b/test/rosen.py
@@ -1,0 +1,5 @@
+from scipy.optimize import rosen, rosen_der
+from ipopt import minimize_ipopt
+x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
+res = minimize_ipopt(rosen, x0, jac=rosen_der)
+print(res)


### PR DESCRIPTION
- Also added the simple minimize_ipopt example to the tests.