### PR TITLE
Added OSError to handle pkg-config not finding ipopt.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.2.0
 =====
 
+- OSError now raised if pkg-config can't find ipopt on installation.
 - Improvements to the README and setup.py for Windows installations.
 - Drop Python 3.4 support and add Python 3.7 support.
 - Adding installation testing on the Appveyor CI service.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def pkgconfig(*packages, **kw):
 
     if not output:  # output will be an empty string if pkg-config finds nothing
         msg = ('pkg-config was not able to find any of the requested packages '
-               '({}) on your system. Make sure pkg-config can discover the .pc '
+               '{} on your system. Make sure pkg-config can discover the .pc '
                'files associated with the installed packages.')
         raise OSError(msg.format(list(packages)))
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,13 @@ def pkgconfig(*packages, **kw):
     flag_map = {'-I': 'include_dirs', '-L': 'library_dirs', '-l': 'libraries'}
     output = sp.Popen(["pkg-config", "--libs", "--cflags"] + list(packages),
                       stdout=sp.PIPE).communicate()[0]
+
+    if not output:  # output will be an empty string if pkg-config finds nothing
+        msg = ('pkg-config was not able to find any of the requested packages '
+               '({}) on your system. Make sure pkg-config can discover the .pc '
+               'files associated with the installed packages.')
+        raise OSError(msg.format(list(packages)))
+
     if six.PY3:
         output = output.decode('utf8')
     for token in output.split():


### PR DESCRIPTION
Tested locally:

```
moorepants@agni:~/src/cyipopt$ python setup.py 
Package ipopt was not found in the pkg-config search path.
Perhaps you should add the directory containing `ipopt.pc'
to the PKG_CONFIG_PATH environment variable
No package 'ipopt' found
Traceback (most recent call last):
  File "setup.py", line 101, in <module>
    **pkgconfig('ipopt'))]
  File "setup.py", line 57, in pkgconfig
    raise OSError(msg.format(list(packages)))
OSError: pkg-config was not able to find any of the requested packages (['ipopt']) on your system. Make sure pkg-config can discover the .pc files associated with the installed packages.
```