### PR TITLE
Add Ipopt 3.13 support for Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.3.0dev0
+=========
+- Added support for Ipopt >=3.13 on Windows.
+  (https://github.com/matthias-k/cyipopt/pull/63)
+
 0.2.0
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ dependencies:
 
   * C/C++ compiler
   * pkg-config [only for Linux and Mac]
-  * Ipopt [<3.13.0 and >= 3.10.1 for Windows]
+  * Ipopt [>3.13.0 for Windows]
   * Python 2.7 or 3.6+
   * setuptools
   * cython
@@ -88,7 +88,6 @@ dependencies:
   * six
   * future
   * scipy [optional]
-  * mkl [windows]
 
 The binaries and header files of the Ipopt package can be obtained from
 http://www.coin-or.org/download/binary/Ipopt/. These include a version compiled
@@ -111,7 +110,11 @@ From source on Windows
 
 Install the dependencies with conda (Anaconda or Miniconda)::
 
-   conda.exe install -c conda-forge numpy cython future six setuptools mkl
+   conda.exe install -c conda-forge numpy cython future six setuptools
+
+Or alternatively with pip::
+
+   pip install numpy cython future six setuptools
 
 Additionally, make sure you have a C compiler setup to compile Python C
 extensions, e.g. Visual C++. Build tools for VS2019
@@ -121,24 +124,23 @@ https://github.com/matthias-k/cyipopt/issues/52).
 
 Download and extract the cyipopt source code from Github or PyPi.
 
-Download a precompiled version of Ipopt that includes the DLL files from
-http://www.coin-or.org/download/binary/Ipopt/. Note that the current setup only
-supports Ipopt >= 3.10.1. It is advised to use the build 3.11.0 by downloading
-the `Ipopt-3.11.0-Win32-Win64-dll.7z
-<https://www.coin-or.org/download/binary/Ipopt/Ipopt-3.11.0-Win32-Win64-dll.7z>`_
-archive. After Ipopt is extracted, the ``lib`` and ``include`` folders should
+Download the latest precompiled version of Ipopt that includes the DLL files from
+https://github.com/coin-or/Ipopt/releases. Note that the current setup only
+supports Ipopt >= 3.13.0. The build 3.13.2 of Ipopt has been confirmed to work and
+can be downloaded from `Ipopt-3.13.2-win64-msvs2019-md.zip
+<https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.2/Ipopt-3.13.2-win64-msvs2019-md.zip>`_
+. After Ipopt is extracted, the ``bin``, ``lib`` and ``include`` folders should
 be in the root cyipopt directory, i.e. adjacent to the ``setup.py`` file.
 Alternatively, you can set the environment variable ``IPOPTWINDIR`` to point to
-the directory that contains the ``lib`` and ``include`` directories.
+the Ipopt directory that contains the ``bin``, ``lib`` and ``include`` directories.
 
 Finally, execute::
 
    python setup.py install
 
-**NOTE:** Only conda Python has been tested to work at the moment, and *not*
-the official python.org distribution. There is likely a binary compatibility
-issue between the C compiler used to build IPOPT and that used for compiling
-Python extensions in the official Python distribution (see
+**NOTE:** It is advised to use the Anaconda or Miniconda distributions and *not* the
+official python.org distribution. Even though it has been tested to work with the
+latest builds, it is well-known for causing issues. (see
 https://github.com/matthias-k/cyipopt/issues/52).
 
 Example Installation on Ubuntu 18.04 Using Dependencies Installed Via APT

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
 
   global:
-    IPOPTWINDIR: "C:\\projects\\cyipopt"
+    IPOPTWINDIR: "C:\\projects\\cyipopt\\Ipopt-3.13.2-win64-msvs2019-md"
 
   matrix:
     - PYTHON: "C:\\Miniconda-x64"
@@ -38,14 +38,14 @@ install:
   - "%PYTHON%\\Scripts\\conda.exe update --yes conda"
   - "%PYTHON%\\Scripts\\conda.exe update --yes --all"
   - "%PYTHON%\\Scripts\\conda.exe config --prepend channels conda-forge"
-  - '%PYTHON%\\Scripts\\conda.exe install --yes python=%PYTHON_VERSION% numpy cython future six setuptools sphinx numpydoc mkl'
+  - "%PYTHON%\\Scripts\\conda.exe install --yes python=%PYTHON_VERSION% numpy cython future six setuptools sphinx numpydoc"
   - "%PYTHON%\\Scripts\\conda.exe update -y --all"
   - "%PYTHON%\\Scripts\\conda.exe info"
   - "%PYTHON%\\Scripts\\conda.exe list"
 
   # This downloads and extracts a precomplied IPOPT for Windows.
-  - ps: Start-FileDownload 'https://www.coin-or.org/download/binary/Ipopt/Ipopt-3.11.0-Win32-Win64-dll.7z'
-  - 7z x Ipopt-3.11.0-Win32-Win64-dll.7z
+  - ps: Start-FileDownload 'https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.2/Ipopt-3.13.2-win64-msvs2019-md.zip'
+  - 7z x Ipopt-3.13.2-win64-msvs2019-md.zip
   - ps: "ls"
 
   # Prepend newly installed Python to the PATH of this build (this cannot be

--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,13 @@ if __name__ == '__main__':
 
         ipoptdir = os.environ.get('IPOPTWINDIR', '')
 
-        IPOPT_INCLUDE_DIRS = [os.path.join(ipoptdir, 'include', 'coin'),
+        IPOPT_INCLUDE_DIRS = [os.path.join(ipoptdir, 'include', 'coin-or'),
                               np.get_include()]
-        IPOPT_LIBS = ['Ipopt-vc8', 'IpOptFSS', 'IpOpt-vc10']
-        IPOPT_LIB_DIRS = [os.path.join(ipoptdir, 'lib', 'x64', 'ReleaseMKL')]
-        IPOPT_DLL = ['IpOptFSS.dll', 'Ipopt-vc8.dll', 'IpOpt-vc10.dll',
-                     'msvcp100.dll', 'msvcr100.dll']
+        IPOPT_LIBS = ['ipopt.dll', 'ipoptamplinterface.dll']
+        IPOPT_LIB_DIRS = [os.path.join(ipoptdir, 'lib')]
+        IPOPT_DLL = ['ipopt-3.dll', 'ipoptamplinterface-3.dll', 'libifcoremd.dll',
+                     'libmmd.dll', 'msvcp140.dll', 'svml_dispmd.dll', 'vcruntime140.dll']
+        IPOPT_DLL_DIRS = [os.path.join(ipoptdir, 'bin')]
 
         EXT_MODULES = [
             Extension(
@@ -92,7 +93,7 @@ if __name__ == '__main__':
             )
         ]
         DATA_FILES = [(get_python_lib(),
-                      [os.path.join(IPOPT_LIB_DIRS[0], dll)
+                      [os.path.join(IPOPT_DLL_DIRS[0], dll)
                       for dll in IPOPT_DLL])] if IPOPT_DLL else None
         include_package_data = False
 


### PR DESCRIPTION
Issue #62 

This updates the `setup.py` files to work with precompiled Ipopt 3.13.XX binaries for Windows (tested with Ipopt 3.13.2 from their [Github](https://github.com/coin-or/Ipopt/releases)). As explained in the Issue thread, this breaks compatibility with older Ipopt precompiled versions because of the different structure. According to feedback, a environment variable could be introduced to specify the Ipopt version.

Edit: I don't know if this has to do with the new Ipopt build system, but this works equally on anaconda and python.org Python with the dependencies installed via pip.