### PR TITLE
Proposal for version 0.3.0 release

### DIFF
--- a/ipopt/version.py
+++ b/ipopt/version.py
@@ -13,4 +13,4 @@ URL: https://github.com/matthias-k/cyipopt
 License: EPL 1.0
 """
 
-__version__ = '0.3.0.dev0'
+__version__ = '0.3.0'


### PR DESCRIPTION
A placeholder PR to discuss and make changes required for a version 0.3.0 release. A 0.3.0 release is needed so that Cyipopt universally supports Ipopt 3.13 on Linux, macOS and Windows on PyPI/conda-forge.